### PR TITLE
Fix: Add missing package, which is preventing swagger-ui from loading, and ChatGPT from importing the plugin

### DIFF
--- a/sk-csharp-azure-functions/sk-csharp-azure-functions.csproj
+++ b/sk-csharp-azure-functions/sk-csharp-azure-functions.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.OpenApi" Version="2.0.0-preview2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.OpenApi" Version="2.0.0-preview2" TreatAsUsed="true" />
     <PackageReference Include="Microsoft.SemanticKernel" Version="0.17.230711.7-preview" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.7.0-2.final" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation and Context

This change is required to fix the issue with failure to fetch `swagger.json` due to a missing assembly `Microsoft.CodeAnalysis`. This is a blocker for user's onboarding by following Readme, as ChatGPT was unable to load the manifest when trying to fetch swagger.json, as shown below.

This fix will ensure that swagger.json will be fetchable and OpenAI is able to fetch the plugin as expected. 

![image](https://github.com/microsoft/semantic-kernel-starters/assets/18152044/1c9be645-a06b-4e10-9f2e-d46a36e86bf5)


![image](https://github.com/microsoft/semantic-kernel-starters/assets/18152044/98bfd069-e994-43c5-acaa-6027a1607984)

### Description

This PR fixes the issue by adding 'Microsoft.CodeAnalysis' package (version 4.7.0-2.final) as a reference in the project file. The 'Microsoft.CodeAnalysis' assembly was missing, causing Swagger UI load to fail. By adding this assembly, the ChatGPT (or, SK's chat-copilot) will now be able to fetch `swagger.json`.

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel-starters/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
