### PR TITLE
Bump sk

### DIFF
--- a/sk-csharp-azure-functions/sk-csharp-azure-functions.csproj
+++ b/sk-csharp-azure-functions/sk-csharp-azure-functions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RepoRoot>$([System.IO.Path]::GetDirectoryName($([MSBuild]::GetPathOfFileAbove('.gitignore', '$(MSBuildThisFileDirectory)'))))</RepoRoot>
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.18.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.OpenApi" Version="2.0.0-preview2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.OpenApi" Version="2.0.0-preview2" TreatAsUsed="true" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="0.17.230711.7-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="0.18.230725.3-preview" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sk-csharp-chatgpt-plugin/README.md
+++ b/sk-csharp-chatgpt-plugin/README.md
@@ -53,5 +53,6 @@ To build and run the Azure Functions application from a terminal use the followi
 ```powershell
 cd azure-function
 dotnet build
-func start --csharp
+cd bin/Debug/net6.0
+func host start  
 ```

--- a/sk-csharp-chatgpt-plugin/azure-function/sk-chatgpt-azure-function.csproj
+++ b/sk-csharp-chatgpt-plugin/azure-function/sk-chatgpt-azure-function.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.18.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.OpenApi" Version="2.0.0-preview2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.OpenApi" Version="2.0.0-preview2" TreatAsUsed="true" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="0.17.230711.7-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="0.18.230725.3-preview" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sk-csharp-console-chat/sk-csharp-console-chat.csproj
+++ b/sk-csharp-console-chat/sk-csharp-console-chat.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="0.17.230711.7-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="0.18.230725.3-preview" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sk-csharp-hello-world/sk-csharp-hello-world.csproj
+++ b/sk-csharp-hello-world/sk-csharp-hello-world.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="0.17.230711.7-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="0.18.230725.3-preview" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sk_csharp_apim_demo/sk_csharp_apim_demo.csproj
+++ b/sk_csharp_apim_demo/sk_csharp_apim_demo.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Azure.Identity" Version="1.9.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="0.17.230711.7-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="0.18.230725.3-preview" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation and Context

  1. Why is this change required? Starters should use the latest versions of SK.
  2. What problem does it solve? Starters being out of sync with the latest SK docs.
  3. What scenario does it contribute to? VSCode starter projects.
  4. If it fixes an open issue, please link to the issue here.



### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Upgraded SK nuget package version in all C# starters and updated the README for the ChatGPT Plugin project. The old instructions resulted in a runtime error when accessing the Swagger page. Talked to Matthew and the issue had to do with Azure Functions removing dependencies it doesn't need. This was the workaround for the issue.


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [X] The code builds clean without any errors or warnings
- [X] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel-starters/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
