### PR TITLE
Fix ChatGPT starter so it works in Chat Copilot

### DIFF
--- a/sk-python-flask-chatgpt-plugin/openapi.yaml
+++ b/sk-python-flask-chatgpt-plugin/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: Semantic Kernel Plugin
   description: A plugin that allows the user to call Semantic Kernel Functions.
@@ -9,7 +9,8 @@ paths:
   /skills/FunSkill/functions/Joke:
     post:
       operationId: executeJokeFunction
-      summary: Execute the joke semantic function
+      description: |
+        Execute the joke semantic function; submit the input and style as a JSON object in the payload input, e.g. {"input": "<JokeSubject>", "style": "<JokeStyle>"}
       requestBody:
         required: True
         content:


### PR DESCRIPTION
### Motivation and Context
The Python ChatGPT starter doesn't work out-of-the-box in Chat Copilot. This PR fixes it.


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel-starters/blob/main/CONTRIBUTING.md)
- [ ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
