### PR TITLE
Add troubleshooting steps when endpoint type doesn't match model used

### DIFF
--- a/sk-csharp-azure-functions/README.md
+++ b/sk-csharp-azure-functions/README.md
@@ -80,3 +80,17 @@ To build and run the Azure Functions application from a terminal use the followi
 dotnet build
 func start --csharp
 ```
+
+## Troubleshooting
+
+### Getting a 400 (BadRequest) and error "Azure.RequestFailedException: logprobs, best_of and echo parameters are not available on gpt-35-turbo model. Please remove the parameter and try again."
+
+A chat completion model (gpt-35-turbo) was set in serviceId/deploymentOrModelId while the kernel was configured to use a text completion model. The type of model used by the kernel can be configured with the endpointType secret. To fix, you can either:
+
+- change endpointType to chat-completion
+
+```powershell
+dotnet user-secrets set "endpointType" "chat-completion"
+```
+
+- change serviceId and deploymentOrModelId to a text completion service like "text-davinci-003": [See Using .NET Secret Manager](#using-net-secret-manager).

--- a/sk-csharp-azure-functions/README.md
+++ b/sk-csharp-azure-functions/README.md
@@ -26,8 +26,8 @@ Configure an OpenAI endpoint
 ```powershell
 cd sk-csharp-azure-functions
 dotnet user-secrets set "serviceType" "OpenAI"
-dotnet user-secrets set "serviceId" "text-davinci-003"
-dotnet user-secrets set "deploymentOrModelId" "text-davinci-003"
+dotnet user-secrets set "serviceId" "gpt-3.5-turbo"
+dotnet user-secrets set "deploymentOrModelId" "gpt-3.5-turbo"
 dotnet user-secrets set "apiKey" "... your OpenAI key ..."
 ```
 
@@ -36,8 +36,8 @@ Configure an Azure OpenAI endpoint
 ```powershell
 cd sk-csharp-azure-functions
 dotnet user-secrets set "serviceType" "AzureOpenAI"
-dotnet user-secrets set "serviceId" "text-davinci-003"
-dotnet user-secrets set "deploymentOrModelId" "text-davinci-003"
+dotnet user-secrets set "serviceId" "gpt-35-turbo"
+dotnet user-secrets set "deploymentOrModelId" "gpt-35-turbo"
 dotnet user-secrets set "endpoint" "https:// ... your endpoint ... .openai.azure.com/"
 dotnet user-secrets set "apiKey" "... your Azure OpenAI key ..."
 ```
@@ -93,4 +93,4 @@ A chat completion model (gpt-35-turbo) was set in serviceId/deploymentOrModelId 
 dotnet user-secrets set "endpointType" "chat-completion"
 ```
 
-- change serviceId and deploymentOrModelId to a text completion service like "text-davinci-003": [See Using .NET Secret Manager](#using-net-secret-manager).
+- change serviceId and deploymentOrModelId to a text completion service like "text-davinci-003": [See Using .NET Secret Manager](#using-net-secret-manager). Please note that the [text-davinci-003 model will be phased out in the future](https://techcommunity.microsoft.com/t5/azure-ai-services-blog/announcing-updates-to-azure-openai-service-models/ba-p/3866757).

--- a/sk-csharp-azure-functions/config/EndpointTypes.cs
+++ b/sk-csharp-azure-functions/config/EndpointTypes.cs
@@ -1,0 +1,5 @@
+﻿internal static class EndpointTypes
+{
+    internal const string TextCompletion = "text-completion";
+    internal const string ChatCompletion = "chat-completion";
+}

--- a/sk-csharp-azure-functions/config/KernelBuilderExtensions.cs
+++ b/sk-csharp-azure-functions/config/KernelBuilderExtensions.cs
@@ -13,11 +13,25 @@ internal static class KernelBuilderExtensions
         switch (kernelSettings.ServiceType.ToUpperInvariant())
         {
             case ServiceTypes.AzureOpenAI:
-                kernelBuilder.WithAzureTextCompletionService(deploymentName: kernelSettings.DeploymentOrModelId, endpoint: kernelSettings.Endpoint, apiKey: kernelSettings.ApiKey, serviceId: kernelSettings.ServiceId);
+                if (kernelSettings.EndpointType == EndpointTypes.TextCompletion)
+                {
+                    kernelBuilder.WithAzureTextCompletionService(deploymentName: kernelSettings.DeploymentOrModelId, endpoint: kernelSettings.Endpoint, apiKey: kernelSettings.ApiKey, serviceId: kernelSettings.ServiceId);
+                }
+                else if (kernelSettings.EndpointType == EndpointTypes.ChatCompletion)
+                {
+                    kernelBuilder.WithAzureChatCompletionService(deploymentName: kernelSettings.DeploymentOrModelId, endpoint: kernelSettings.Endpoint, apiKey: kernelSettings.ApiKey, serviceId: kernelSettings.ServiceId);
+                }
                 break;
 
             case ServiceTypes.OpenAI:
-                kernelBuilder.WithOpenAITextCompletionService(modelId: kernelSettings.DeploymentOrModelId, apiKey: kernelSettings.ApiKey, orgId: kernelSettings.OrgId, serviceId: kernelSettings.ServiceId);
+                if (kernelSettings.EndpointType == EndpointTypes.TextCompletion)
+                {
+                    kernelBuilder.WithOpenAITextCompletionService(modelId: kernelSettings.DeploymentOrModelId, apiKey: kernelSettings.ApiKey, orgId: kernelSettings.OrgId, serviceId: kernelSettings.ServiceId);
+                }
+                else if (kernelSettings.EndpointType == EndpointTypes.ChatCompletion)
+                {
+                    kernelBuilder.WithOpenAIChatCompletionService(modelId: kernelSettings.DeploymentOrModelId, apiKey: kernelSettings.ApiKey, orgId: kernelSettings.OrgId, serviceId: kernelSettings.ServiceId);
+                }
                 break;
 
             default:

--- a/sk-csharp-azure-functions/config/KernelBuilderExtensions.cs
+++ b/sk-csharp-azure-functions/config/KernelBuilderExtensions.cs
@@ -12,28 +12,18 @@ internal static class KernelBuilderExtensions
     {
         switch (kernelSettings.ServiceType.ToUpperInvariant())
         {
-            case ServiceTypes.AzureOpenAI:
-                if (kernelSettings.EndpointType == EndpointTypes.TextCompletion)
-                {
-                    kernelBuilder.WithAzureTextCompletionService(deploymentName: kernelSettings.DeploymentOrModelId, endpoint: kernelSettings.Endpoint, apiKey: kernelSettings.ApiKey, serviceId: kernelSettings.ServiceId);
-                }
-                else if (kernelSettings.EndpointType == EndpointTypes.ChatCompletion)
-                {
-                    kernelBuilder.WithAzureChatCompletionService(deploymentName: kernelSettings.DeploymentOrModelId, endpoint: kernelSettings.Endpoint, apiKey: kernelSettings.ApiKey, serviceId: kernelSettings.ServiceId);
-                }
+            case ServiceTypes.AzureOpenAI when kernelSettings.EndpointType == EndpointTypes.TextCompletion:
+                kernelBuilder.WithAzureTextCompletionService(deploymentName: kernelSettings.DeploymentOrModelId, endpoint: kernelSettings.Endpoint, apiKey: kernelSettings.ApiKey, serviceId: kernelSettings.ServiceId);
                 break;
-
-            case ServiceTypes.OpenAI:
-                if (kernelSettings.EndpointType == EndpointTypes.TextCompletion)
-                {
-                    kernelBuilder.WithOpenAITextCompletionService(modelId: kernelSettings.DeploymentOrModelId, apiKey: kernelSettings.ApiKey, orgId: kernelSettings.OrgId, serviceId: kernelSettings.ServiceId);
-                }
-                else if (kernelSettings.EndpointType == EndpointTypes.ChatCompletion)
-                {
-                    kernelBuilder.WithOpenAIChatCompletionService(modelId: kernelSettings.DeploymentOrModelId, apiKey: kernelSettings.ApiKey, orgId: kernelSettings.OrgId, serviceId: kernelSettings.ServiceId);
-                }
+            case ServiceTypes.AzureOpenAI when kernelSettings.EndpointType == EndpointTypes.ChatCompletion:
+                kernelBuilder.WithAzureChatCompletionService(deploymentName: kernelSettings.DeploymentOrModelId, endpoint: kernelSettings.Endpoint, apiKey: kernelSettings.ApiKey, serviceId: kernelSettings.ServiceId);
                 break;
-
+            case ServiceTypes.OpenAI when kernelSettings.EndpointType == EndpointTypes.TextCompletion:
+                kernelBuilder.WithOpenAITextCompletionService(modelId: kernelSettings.DeploymentOrModelId, apiKey: kernelSettings.ApiKey, orgId: kernelSettings.OrgId, serviceId: kernelSettings.ServiceId);
+                break;
+            case ServiceTypes.OpenAI when kernelSettings.EndpointType == EndpointTypes.ChatCompletion:
+                kernelBuilder.WithOpenAIChatCompletionService(modelId: kernelSettings.DeploymentOrModelId, apiKey: kernelSettings.ApiKey, orgId: kernelSettings.OrgId, serviceId: kernelSettings.ServiceId);
+                break;
             default:
                 throw new ArgumentException($"Invalid service type value: {kernelSettings.ServiceType}");
         }

--- a/sk-csharp-azure-functions/config/KernelSettings.cs
+++ b/sk-csharp-azure-functions/config/KernelSettings.cs
@@ -8,7 +8,7 @@ internal class KernelSettings
     public const string DefaultConfigFile = "config/appsettings.json";
 
     [JsonPropertyName("endpointType")]
-    public string EndpointType { get; set; } = EndpointTypes.TextCompletion;
+    public string EndpointType { get; set; } = EndpointTypes.ChatCompletion;
 
     [JsonPropertyName("serviceType")]
     public string ServiceType { get; set; } = string.Empty;

--- a/sk-csharp-azure-functions/config/KernelSettings.cs
+++ b/sk-csharp-azure-functions/config/KernelSettings.cs
@@ -7,6 +7,9 @@ internal class KernelSettings
 {
     public const string DefaultConfigFile = "config/appsettings.json";
 
+    [JsonPropertyName("endpointType")]
+    public string EndpointType { get; set; } = EndpointTypes.TextCompletion;
+
     [JsonPropertyName("serviceType")]
     public string ServiceType { get; set; } = string.Empty;
 

--- a/sk-csharp-chatgpt-plugin/README.md
+++ b/sk-csharp-chatgpt-plugin/README.md
@@ -1,6 +1,7 @@
 # Semantic Kernel ChatGPT plugin starter
 
 This project provides starter code to create a ChatGPT plugin. It includes the following components:
+
 - An endpoint that serves up an ai-plugin.json file for ChatGPT to discover the plugin
 - A generator that automatically converts prompts into semantic function endpoints
 - The ability to add additional native functions as endpoints to the plugin
@@ -23,7 +24,6 @@ To configure the starter, you need to provide the following information:
 - Enter the API key for your AI endpoint in the [local.settings.json](./azure-function/local.settings.json) file.
 
 For Debugging the console application alone, we suggest using .NET [Secret Manager](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets) to avoid the risk of leaking secrets into the repository, branches and pull requests.
-
 
 ### Using appsettings.json
 

--- a/sk-csharp-hello-world/README.md
+++ b/sk-csharp-hello-world/README.md
@@ -79,3 +79,17 @@ To build and run the console application from the terminal use the following com
 dotnet build
 dotnet run
 ```
+
+## Troubleshooting
+
+### Getting a 400 (BadRequest) and error "Azure.RequestFailedException: logprobs, best_of and echo parameters are not available on gpt-35-turbo model. Please remove the parameter and try again."
+
+A chat completion model (gpt-35-turbo) was set in serviceId/deploymentOrModelId while the kernel was configured to use a text completion model. The type of model used by the kernel can be configured with the endpointType secret. To fix, you can either:
+
+- change endpointType to chat-completion
+
+```powershell
+dotnet user-secrets set "endpointType" "chat-completion"
+```
+
+- change serviceId and deploymentOrModelId to a text completion service like "text-davinci-003": [See Using .NET Secret Manager](#using-net-secret-manager).

--- a/sk-csharp-hello-world/README.md
+++ b/sk-csharp-hello-world/README.md
@@ -25,8 +25,8 @@ Configure an OpenAI endpoint
 ```powershell
 cd sk-csharp-hello-world
 dotnet user-secrets set "serviceType" "OpenAI"
-dotnet user-secrets set "serviceId" "text-davinci-003"
-dotnet user-secrets set "deploymentOrModelId" "text-davinci-003"
+dotnet user-secrets set "serviceId" "gpt-3.5-turbo"
+dotnet user-secrets set "deploymentOrModelId" "gpt-3.5-turbo"
 dotnet user-secrets set "apiKey" "... your OpenAI key ..."
 ```
 
@@ -35,8 +35,8 @@ Configure an Azure OpenAI endpoint
 ```powershell
 cd sk-csharp-hello-world
 dotnet user-secrets set "serviceType" "AzureOpenAI"
-dotnet user-secrets set "serviceId" "text-davinci-003"
-dotnet user-secrets set "deploymentOrModelId" "text-davinci-003"
+dotnet user-secrets set "serviceId" "gpt-35-turbo"
+dotnet user-secrets set "deploymentOrModelId" "gpt-35-turbo"
 dotnet user-secrets set "endpoint" "https:// ... your endpoint ... .openai.azure.com/"
 dotnet user-secrets set "apiKey" "... your Azure OpenAI key ..."
 ```
@@ -92,4 +92,4 @@ A chat completion model (gpt-35-turbo) was set in serviceId/deploymentOrModelId 
 dotnet user-secrets set "endpointType" "chat-completion"
 ```
 
-- change serviceId and deploymentOrModelId to a text completion service like "text-davinci-003": [See Using .NET Secret Manager](#using-net-secret-manager).
+- change serviceId and deploymentOrModelId to a text completion service like "text-davinci-003": [See Using .NET Secret Manager](#using-net-secret-manager). Please note that the [text-davinci-003 model will be phased out in the future](https://techcommunity.microsoft.com/t5/azure-ai-services-blog/announcing-updates-to-azure-openai-service-models/ba-p/3866757).

--- a/sk-csharp-hello-world/config/KernelBuilderExtensions.cs
+++ b/sk-csharp-hello-world/config/KernelBuilderExtensions.cs
@@ -12,28 +12,18 @@ internal static class KernelBuilderExtensions
     {
         switch (kernelSettings.ServiceType.ToUpperInvariant())
         {
-            case ServiceTypes.AzureOpenAI:
-                if (kernelSettings.EndpointType == EndpointTypes.TextCompletion)
-                {
-                    kernelBuilder.WithAzureTextCompletionService(deploymentName: kernelSettings.DeploymentOrModelId, endpoint: kernelSettings.Endpoint, apiKey: kernelSettings.ApiKey, serviceId: kernelSettings.ServiceId);
-                }
-                else if (kernelSettings.EndpointType == EndpointTypes.ChatCompletion)
-                {
-                    kernelBuilder.WithAzureChatCompletionService(deploymentName: kernelSettings.DeploymentOrModelId, endpoint: kernelSettings.Endpoint, apiKey: kernelSettings.ApiKey, serviceId: kernelSettings.ServiceId);
-                }
+            case ServiceTypes.AzureOpenAI when kernelSettings.EndpointType == EndpointTypes.TextCompletion:
+                kernelBuilder.WithAzureTextCompletionService(deploymentName: kernelSettings.DeploymentOrModelId, endpoint: kernelSettings.Endpoint, apiKey: kernelSettings.ApiKey, serviceId: kernelSettings.ServiceId);
                 break;
-
-            case ServiceTypes.OpenAI:
-                if (kernelSettings.EndpointType == EndpointTypes.TextCompletion)
-                {
-                    kernelBuilder.WithOpenAITextCompletionService(modelId: kernelSettings.DeploymentOrModelId, apiKey: kernelSettings.ApiKey, orgId: kernelSettings.OrgId, serviceId: kernelSettings.ServiceId);
-                }
-                else if (kernelSettings.EndpointType == EndpointTypes.ChatCompletion)
-                {
-                    kernelBuilder.WithOpenAIChatCompletionService(modelId: kernelSettings.DeploymentOrModelId, apiKey: kernelSettings.ApiKey, orgId: kernelSettings.OrgId, serviceId: kernelSettings.ServiceId);
-                }
+            case ServiceTypes.AzureOpenAI when kernelSettings.EndpointType == EndpointTypes.ChatCompletion:
+                kernelBuilder.WithAzureChatCompletionService(deploymentName: kernelSettings.DeploymentOrModelId, endpoint: kernelSettings.Endpoint, apiKey: kernelSettings.ApiKey, serviceId: kernelSettings.ServiceId);
                 break;
-
+            case ServiceTypes.OpenAI when kernelSettings.EndpointType == EndpointTypes.TextCompletion:
+                kernelBuilder.WithOpenAITextCompletionService(modelId: kernelSettings.DeploymentOrModelId, apiKey: kernelSettings.ApiKey, orgId: kernelSettings.OrgId, serviceId: kernelSettings.ServiceId);
+                break;
+            case ServiceTypes.OpenAI when kernelSettings.EndpointType == EndpointTypes.ChatCompletion:
+                kernelBuilder.WithOpenAIChatCompletionService(modelId: kernelSettings.DeploymentOrModelId, apiKey: kernelSettings.ApiKey, orgId: kernelSettings.OrgId, serviceId: kernelSettings.ServiceId);
+                break;
             default:
                 throw new ArgumentException($"Invalid service type value: {kernelSettings.ServiceType}");
         }

--- a/sk-csharp-hello-world/config/KernelSettings.cs
+++ b/sk-csharp-hello-world/config/KernelSettings.cs
@@ -7,7 +7,7 @@ internal class KernelSettings
     public const string DefaultConfigFile = "config/appsettings.json";
 
     [JsonPropertyName("endpointType")]
-    public string EndpointType { get; set; } = EndpointTypes.TextCompletion;
+    public string EndpointType { get; set; } = EndpointTypes.ChatCompletion;
 
     [JsonPropertyName("serviceType")]
     public string ServiceType { get; set; } = string.Empty;


### PR DESCRIPTION
### Motivation and Context

Please help reviewers and future users, providing the following information:
  1. Why is this change required? Helps developers that don't understand why they're getting a certain error from the LLM.
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.



### Description
An [issue](https://github.com/microsoft/semantic-kernel/issues/1564) I created while trying to run one of the starters with the gpt-35-turbo model received feedback from other developers that they ran into the same issue. Given that this is a common issue, I wanted to add troubleshooting steps closer to the starter code. Additionally, I made the CSharp Azure Function project endpoint type configurable such that it can use either a text or chat completion endpoint for developers who are limited to certain model types.


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel-starters/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
