### PR TITLE
Fixed sk-csharp-console-chat tasks for build/debug

### DIFF
--- a/sk-csharp-console-chat/.vscode/settings.json
+++ b/sk-csharp-console-chat/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "dotnet.defaultSolution": "sk-csharp-console-chat.sln"
-}

--- a/sk-csharp-console-chat/.vscode/tasks.json
+++ b/sk-csharp-console-chat/.vscode/tasks.json
@@ -7,7 +7,7 @@
             "type": "process",
             "args": [
                 "build",
-                "${workspaceFolder}/sk-csharp-console-chat.sln",
+                "${workspaceFolder}/sk-csharp-console-chat.csproj",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],
@@ -19,7 +19,7 @@
             "type": "process",
             "args": [
                 "publish",
-                "${workspaceFolder}/sk-csharp-console-chat.sln",
+                "${workspaceFolder}/sk-csharp-console-chat.csproj",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],
@@ -33,7 +33,7 @@
                 "watch",
                 "run",
                 "--project",
-                "${workspaceFolder}/sk-csharp-console-chat.sln"
+                "${workspaceFolder}/sk-csharp-console-chat.csproj"
             ],
             "problemMatcher": "$msCompile"
         }


### PR DESCRIPTION
### Motivation and Context
Using the Get Started link from the SK Tools in VSCode, I created a new app and selected Console Chat. This got the required files for running the sk-csharp-hello-world starter project but hitting F5 fails due to the tasks.json referencing sk-csharp-hello-world.sln which does not exist.

This addresses Issue https://github.com/microsoft/semantic-kernel-starters/issues/75


### Description
Updated tasks.json to reference the sk-csharp-hello-world.csproj instead of the .sln that doesn't exist.


### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [X] The code builds clean without any errors or warnings
- [X] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel-starters/blob/main/CONTRIBUTING.md)
- [X] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
