### PR TITLE
Add instructions for running sk_python_flask_chatgpt_plugin locally

### DIFF
--- a/sk-python-flask-chatgpt-plugin/README.md
+++ b/sk-python-flask-chatgpt-plugin/README.md
@@ -48,7 +48,11 @@ On each HTTP request, use these headers:
 ## Running the starter
 
 To run the console application within Visual Studio Code, just hit `F5`.
-As configured in `launch.json` and `tasks.json`, Visual Studio Code will run `poetry install` followed by `python -m flask run sk_python_flask/app.py`.  Some users have had issues if there are spaces in their folder names.
+As configured in `launch.json` and `tasks.json`, Visual Studio Code will run `poetry install` followed by `python -m flask run sk_python_flask_chatgpt_plugin/app.py`.  Some users have had issues if there are spaces in their folder names.
+
+To run the console application using CLI:
+1. `poetry install`
+2. `python -m flask --app sk_python_flask_chatgpt_plugin/app.py run --port 5050 --debug`
 
 A POST endpoint exists at `localhost:5050/skills/{skill_name}/functions/{function_name}`
 For example, send a POST request to `localhost:5050/skills/FunSkill/functions/Joke` with the configuration headers


### PR DESCRIPTION
### Motivation and Context
<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

Current instructions only share how to run using VS Code.

### Description
<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

Only updated the `sk-python-flask-chatgpt-plugin/README.md` file with the new instructions. No code changed.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel-starters/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
