### PR TITLE
Update the console starter to use the newest version of semantic kernel

### DIFF
--- a/sk-csharp-console-chat/ConsoleChat.cs
+++ b/sk-csharp-console-chat/ConsoleChat.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Extensions.Hosting;
 using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.AI.ChatCompletion;
-using Microsoft.SemanticKernel.Connectors.AI.OpenAI;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
 
 /// <summary>
 /// This is the main application service.
@@ -48,15 +48,9 @@ internal class ConsoleChat : IHostedService
             System.Console.Write("User > ");
             chatMessages.AddUserMessage(Console.ReadLine()!);
 
-            // Get the chat completions
-            OpenAIPromptExecutionSettings openAIPromptExecutionSettings = new()
-            {
-                FunctionCallBehavior = FunctionCallBehavior.AutoInvokeKernelFunctions
-            };
             IAsyncEnumerable<StreamingChatMessageContent> result =
                 chatCompletionService.GetStreamingChatMessageContentsAsync(
                     chatMessages,
-                    executionSettings: openAIPromptExecutionSettings,
                     kernel: this._kernel,
                     cancellationToken: cancellationToken);
 
@@ -69,12 +63,16 @@ internal class ConsoleChat : IHostedService
                     System.Console.Write("Assistant > ");
                     chatMessageContent = new(
                         content.Role ?? AuthorRole.Assistant,
-                        content.ModelId!,
                         content.Content!,
+                        content.ModelId!,
                         content.InnerContent,
                         content.Encoding,
                         content.Metadata
                     );
+                }
+                if (content.Content is null)
+                {
+                    continue;
                 }
                 System.Console.Write(content.Content);
                 chatMessageContent!.Content += content.Content;

--- a/sk-csharp-console-chat/ConsoleChat.cs
+++ b/sk-csharp-console-chat/ConsoleChat.cs
@@ -48,9 +48,16 @@ internal class ConsoleChat : IHostedService
             System.Console.Write("User > ");
             chatMessages.AddUserMessage(Console.ReadLine()!);
 
+            // Get the chat completions
+            OpenAIPromptExecutionSettings openAIPromptExecutionSettings = new()
+            {
+                ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions
+            };
+
             IAsyncEnumerable<StreamingChatMessageContent> result =
                 chatCompletionService.GetStreamingChatMessageContentsAsync(
                     chatMessages,
+                    openAIPromptExecutionSettings,
                     kernel: this._kernel,
                     cancellationToken: cancellationToken);
 
@@ -78,7 +85,10 @@ internal class ConsoleChat : IHostedService
                 chatMessageContent!.Content += content.Content;
             }
             System.Console.WriteLine();
-            chatMessages.AddMessage(chatMessageContent!);
+            if (chatMessageContent is not null && chatMessageContent.Content is not null)
+            {
+                chatMessages.AddAssistantMessage(chatMessageContent!.Content ?? "");
+            }
         }
     }
 }

--- a/sk-csharp-console-chat/Program.cs
+++ b/sk-csharp-console-chat/Program.cs
@@ -26,7 +26,7 @@ builder.ConfigureServices((context, services) =>
     services
         .AddSingleton<KernelSettings>(kernelSettings)
         .AddTransient<Kernel>(serviceProvider => {
-            KernelBuilder builder = new();
+            IKernelBuilder builder = Kernel.CreateBuilder();
             builder.Services.AddLogging(c => c.AddDebug().SetMinimumLevel(LogLevel.Information));
             builder.Services.AddChatCompletionService(kernelSettings);
             builder.Plugins.AddFromType<LightPlugin>();

--- a/sk-csharp-console-chat/config/ServiceCollectionExtensions.cs
+++ b/sk-csharp-console-chat/config/ServiceCollectionExtensions.cs
@@ -14,7 +14,7 @@ internal static class ServiceCollectionExtensions
         switch (kernelSettings.ServiceType.ToUpperInvariant())
         {
             case ServiceTypes.AzureOpenAI:
-                serviceCollection = serviceCollection.AddAzureOpenAIChatCompletion(kernelSettings.DeploymentId, kernelSettings.ModelId, endpoint: kernelSettings.Endpoint, apiKey: kernelSettings.ApiKey, serviceId: kernelSettings.ServiceId);
+                serviceCollection = serviceCollection.AddAzureOpenAIChatCompletion(kernelSettings.DeploymentId, endpoint: kernelSettings.Endpoint, apiKey: kernelSettings.ApiKey, serviceId: kernelSettings.ServiceId);
                 break;
 
             case ServiceTypes.OpenAI:

--- a/sk-csharp-console-chat/plugins/LightPlugin.cs
+++ b/sk-csharp-console-chat/plugins/LightPlugin.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel;
 using Microsoft.SemanticKernel;
-using Microsoft.SemanticKernel.AI.ChatCompletion;
+using Microsoft.SemanticKernel.ChatCompletion;
 
 namespace Plugins;
 

--- a/sk-csharp-console-chat/sk-csharp-console-chat.csproj
+++ b/sk-csharp-console-chat/sk-csharp-console-chat.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.0.0" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.0.0-rc3" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation and Context
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  The newest version 1.0.2 has breaking changes in how ChatCompletions are used and gets rid of the functional planner options as well.

### Description
I updated to the latest stable version of semantic kernel, and modified the example so that it resulted in the desired behavior of being a functional terminal based chatbot


### Contribution Checklist
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel-starters/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
![image](https://github.com/microsoft/semantic-kernel-starters/assets/95243381/ab64d959-2e01-4616-aa12-42301472db19)
