### PR TITLE
fix: wrong git clone url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains starter projects for the [Semantic Kernel](https://gith
 
 ## Usage
 
-- `git clone https://github.com/semantic-kernel/semantic-kernel-starters`
+- `git clone https://github.com/microsoft/semantic-kernel-starters`
 - `code <any-sample-folder>`
 - Follow the instructions in each sample's README for setting up and running the sample
 Alternatively, you can use the [Semantic Kernel Tools](https://marketplace.visualstudio.com/items?itemName=ms-semantic-kernel.semantic-kernel) to "Create a New App" using the starters


### PR DESCRIPTION

  1. Why is this change required? -> wrong url in readme file
  2. What problem does it solve? -> correct the url
  3. What scenario does it contribute to? -> contribution / usage
  4. If it fixes an open issue, please link to the issue here. -> it doesn't


- [ x] The code builds clean without any errors or warnings
- [x ] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel-starters/blob/main/CONTRIBUTING.md)
- [x ] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x ] All unit tests pass, and I have added new tests where possible
- [x ] I didn't break anything :smile:
