### PR TITLE
parameters in new ChatMessageContent are not ordered properly

### DIFF
--- a/sk-csharp-console-chat/ConsoleChat.cs
+++ b/sk-csharp-console-chat/ConsoleChat.cs
@@ -69,8 +69,8 @@ internal class ConsoleChat : IHostedService
                     System.Console.Write("Assistant > ");
                     chatMessageContent = new(
                         content.Role ?? AuthorRole.Assistant,
-                        content.ModelId!,
                         content.Content!,
+                        content.ModelId!,
                         content.InnerContent,
                         content.Encoding,
                         content.Metadata

--- a/sk-csharp-hello-world/Program.cs
+++ b/sk-csharp-hello-world/Program.cs
@@ -55,8 +55,8 @@ while (true)
             System.Console.Write("Assistant > ");
             chatMessageContent = new ChatMessageContent(
                 content.Role ?? AuthorRole.Assistant,
-                content.ModelId!,
                 content.Content!,
+                content.ModelId!,
                 content.InnerContent,
                 content.Encoding,
                 content.Metadata);


### PR DESCRIPTION
### Motivation and Context
  1. Why is this change required?
  Chat Message Content are incorrect
2. What problem does it solve?
The modelId incorrectly gets added to the ChatMessageContent.Content
  
 


### Description
The constructor `ChatMessageContent` in `Microsoft.SemanticKernel.Abstractions` expects parameters like so:
```
 [JsonConstructor]
 public ChatMessageContent(
     AuthorRole role,
     string? content,
     string? modelId = null,
     object? innerContent = null,
     Encoding? encoding = null,
     IReadOnlyDictionary<string, object?>? metadata = null)
     : base(innerContent, modelId, metadata)
```
`Content` is expected BEFORE `ModelId`.

### Contribution Checklist
<!-- Before submitting this PR, please make sure: -->
- [x] The code builds clean without any errors or warnings
- [x] The PR follows SK Contribution Guidelines (https://github.com/microsoft/semantic-kernel-starters/blob/main/CONTRIBUTING.md)
- [x] The code follows the .NET coding conventions (https://learn.microsoft.com/dotnet/csharp/fundamentals/coding-style/coding-conventions) verified with `dotnet format`
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
